### PR TITLE
Fix: authentication middleware

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -42,12 +42,12 @@ app.use(helmet({
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 
+// secure your private routes with jwt authentication middleware
+app.all('/private/*', (req, res, next) => auth(req, res, next));
+
 // fill routes for express appliction
 app.use('/public', mappedOpenRoutes);
 app.use('/private', mappedAuthRoutes);
-
-// secure your private routes with jwt authentication middleware
-app.all('/private/*', (req, res, next) => auth(req, res, next));
 
 server.listen(config.port, () => {
   if (environment !== 'production' &&


### PR DESCRIPTION
I am using the boilerplate to guide my folder and file structure for a nodejs,express and mongodb rest api .I realised that if app.use() is placed before app.all(), the middleware is not called because the routes have already been used hence fixing it that way and now it works.  Besides that, this tutorial has been of match help. Hope u see this.