### PR TITLE
Docs: fix typo controllers to models

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ model.exports = ModelController;
 
 ### Create a Model
 
-Controllers in this boilerplate have a naming convention: `Model.js` and uses [Sequelize](http://docs.sequelizejs.com/) to define our Models, if you want further information read the [Docs](http://docs.sequelizejs.com/).
+Models in this boilerplate have a naming convention: `Model.js` and uses [Sequelize](http://docs.sequelizejs.com/) to define our Models, if you want further information read the [Docs](http://docs.sequelizejs.com/).
 
 Example User Model:
 


### PR DESCRIPTION
Changed  "Controllers in this boiler..." to "Models in this boiler..."